### PR TITLE
Force HTTP 1.0 in Guzzle

### DIFF
--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -152,6 +152,9 @@ class Client implements ClientInterface
     private function request($method, $uri, array $options = array())
     {
         $options['auth'] = array($this->accessKey, $this->secretKey);
+        // Force HTTP 1.0
+        // See https://github.com/jackalope/jackalope-jackrabbit/issues/89
+        $options['version'] = 1.0;
 
         return $this->httpClient->request($method, $uri, $options);
     }


### PR DESCRIPTION
Sometimes, CURL throws the error:
cURL error 56: Problem (2) in the Chunked-Encoded data

To fix this, we need to downgrade from HTTP 1.1 to HTTP 1.0